### PR TITLE
Fixes apperance of AYVibrantButton after rotation

### DIFF
--- a/AYVibrantButton/AYVibrantButton.m
+++ b/AYVibrantButton/AYVibrantButton.m
@@ -142,7 +142,10 @@
 	self.visualEffectView.frame = self.bounds;
 #endif
 	self.normalOverlay.frame = self.bounds;
+    [self.normalOverlay setNeedsDisplay];
+    
 	self.highlightedOverlay.frame = self.bounds;
+    [self.highlightedOverlay setNeedsDisplay];
 }
 
 - (void)createOverlays {


### PR DESCRIPTION
AYVibrantButton does not update subviews (both overlays) after device rotation. Thus cached (and oudated) renderings of the overlays are used after changing frame.
